### PR TITLE
Add note about regions in data connection

### DIFF
--- a/modules/chapter2/pages/section3.adoc
+++ b/modules/chapter2/pages/section3.adoc
@@ -130,6 +130,13 @@ Complete the form with your S3 connection parameters.
 
 image::dataconnection-new.png[]
 
+[IMPORTANT]
+====
+For S3 buckets where the region is not relevant, such as Minio, you still have to enter a placeholder value in the btn:[Region] field.
+A non-empty region is required to pass `boto3` validations.
+Otherwise, you might get an `Invalid region` error.
+====
+
 Save the workbench.
 In the data science project page, notice the newly created data connection, which is associated with the workbench.
 


### PR DESCRIPTION
The `boto3` library requires the `region` value to be non-empty.